### PR TITLE
[EAG-96] Add @carecloud/material-cuil dependency.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build
 dist
 lib
 yarn.lock
+
+# Idea
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-jsonschema-form",
-  "version": "1.0.0",
+  "name": "@carecloud/react-jsonschema-form",
+  "version": "0.1.0",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build:readme": "toctoc README.md -w",
@@ -40,6 +40,7 @@
     "react": ">=15"
   },
   "dependencies": {
+    "@carecloud/material-cuil": "0.1.0",
     "ajv": "^5.2.3",
     "lodash.topath": "^4.5.2",
     "prop-types": "^15.5.8",

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { TextField } from "@carecloud/material-cuil";
 
 function BaseInput(props) {
   // Note: since React 15.2.0 we can't forward unknown element attributes, so we
@@ -23,7 +24,7 @@ function BaseInput(props) {
     return props.onChange(value === "" ? options.emptyValue : value);
   };
   return (
-    <input
+    <TextField
       className="form-control"
       readOnly={readonly}
       disabled={disabled}

--- a/src/components/widgets/CheckboxWidget.js
+++ b/src/components/widgets/CheckboxWidget.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import DescriptionField from "../fields/DescriptionField.js";
+import { FormControlLabel, Checkbox } from "@carecloud/material-cuil";
 
 function CheckboxWidget(props) {
   const {
@@ -11,7 +12,6 @@ function CheckboxWidget(props) {
     disabled,
     readonly,
     label,
-    autofocus,
     onChange,
   } = props;
   return (
@@ -19,18 +19,20 @@ function CheckboxWidget(props) {
       {schema.description && (
         <DescriptionField description={schema.description} />
       )}
-      <label>
-        <input
-          type="checkbox"
-          id={id}
-          checked={typeof value === "undefined" ? false : value}
-          required={required}
-          disabled={disabled || readonly}
-          autoFocus={autofocus}
-          onChange={event => onChange(event.target.checked)}
-        />
-        <span>{label}</span>
-      </label>
+
+      <FormControlLabel
+        control={
+          <Checkbox
+            id={id}
+            checked={typeof value === "undefined" ? false : value}
+            value={value}
+            required={required}
+            disabled={disabled || readonly}
+            onChange={event => onChange(event.target.checked)}
+          />
+        }
+        label={label}
+      />
     </div>
   );
 }

--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -1,5 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
+import {
+  FormControlLabel,
+  FormGroup,
+  Checkbox,
+} from "@carecloud/material-cuil";
 
 function selectValue(value, selected, all) {
   const at = all.indexOf(value);
@@ -14,44 +19,42 @@ function deselectValue(value, selected) {
 }
 
 function CheckboxesWidget(props) {
-  const { id, disabled, options, value, autofocus, readonly, onChange } = props;
-  const { enumOptions, inline } = options;
+  const { id, disabled, options, value, readonly, onChange } = props;
+  const { enumOptions, enumDisabled = [], inline } = options;
+  const groupDisabled = disabled || readonly;
+
   return (
-    <div className="checkboxes" id={id}>
+    <FormGroup id={id} name={id} className="checkboxes" row={inline}>
       {enumOptions.map((option, index) => {
+        const isDisabled =
+          groupDisabled || enumDisabled.indexOf(option.value) !== -1;
         const checked = value.indexOf(option.value) !== -1;
-        const disabledCls = disabled || readonly ? "disabled" : "";
-        const checkbox = (
-          <span>
-            <input
-              type="checkbox"
-              id={`${id}_${index}`}
-              checked={checked}
-              disabled={disabled || readonly}
-              autoFocus={autofocus && index === 0}
-              onChange={event => {
-                const all = enumOptions.map(({ value }) => value);
-                if (event.target.checked) {
-                  onChange(selectValue(option.value, value, all));
-                } else {
-                  onChange(deselectValue(option.value, value));
-                }
-              }}
-            />
-            <span>{option.label}</span>
-          </span>
-        );
-        return inline ? (
-          <label key={index} className={`checkbox-inline ${disabledCls}`}>
-            {checkbox}
-          </label>
-        ) : (
-          <div key={index} className={`checkbox ${disabledCls}`}>
-            <label>{checkbox}</label>
-          </div>
+
+        return (
+          <FormControlLabel
+            key={index}
+            control={
+              <Checkbox
+                id={`${id}_${index}`}
+                checked={checked}
+                onChange={event => {
+                  const all = enumOptions.map(({ value }) => value);
+
+                  if (event.target.checked) {
+                    onChange(selectValue(option.value, value, all));
+                  } else {
+                    onChange(deselectValue(option.value, value));
+                  }
+                }}
+                value={option.value}
+                disabled={isDisabled}
+              />
+            }
+            label={option.label}
+          />
         );
       })}
-    </div>
+    </FormGroup>
   );
 }
 

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -1,53 +1,50 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { FormControlLabel, RadioGroup, Radio } from "@carecloud/material-cuil";
 
 function RadioWidget(props) {
-  const {
-    options,
-    value,
-    required,
-    disabled,
-    readonly,
-    autofocus,
-    onChange,
-  } = props;
-  // Generating a unique field name to identify this set of radio buttons
-  const name = Math.random().toString();
-  const { enumOptions, inline } = options;
-  // checked={checked} has been moved above name={name}, As mentioned in #349;
-  // this is a temporary fix for radio button rendering bug in React, facebook/react#7630.
-  return (
-    <div className="field-radio-group">
-      {enumOptions.map((option, i) => {
-        const checked = option.value === value;
-        const disabledCls = disabled || readonly ? "disabled" : "";
-        const radio = (
-          <span>
-            <input
-              type="radio"
-              checked={checked}
-              name={name}
-              required={required}
-              value={option.value}
-              disabled={disabled || readonly}
-              autoFocus={autofocus && i === 0}
-              onChange={_ => onChange(option.value)}
-            />
-            <span>{option.label}</span>
-          </span>
-        );
+  const { id, options, value, required, disabled, readonly, onChange } = props;
+  const { enumOptions, enumDisabled = [], inline } = options;
+  const groupDisabled = disabled || readonly;
 
-        return inline ? (
-          <label key={i} className={`radio-inline ${disabledCls}`}>
-            {radio}
-          </label>
-        ) : (
-          <div key={i} className={`radio ${disabledCls}`}>
-            <label>{radio}</label>
-          </div>
+  return (
+    <RadioGroup
+      className="field-radio-group"
+      name={id}
+      required={required}
+      value={value != null ? value.toString() : value}
+      row={inline}
+      onChange={(event, value) => {
+        // BooleanField expects a boolean for the value property
+        switch (value) {
+          case "true":
+            value = true;
+            break;
+          case "false":
+            value = false;
+            break;
+          default:
+            break;
+        }
+
+        onChange(value);
+      }}>
+      {enumOptions.map((option, index) => {
+        const optionValue = option.value.toString();
+        const isDisabled =
+          groupDisabled || enumDisabled.indexOf(option.value) !== -1;
+
+        return (
+          <FormControlLabel
+            key={index}
+            disabled={isDisabled}
+            control={<Radio />}
+            value={optionValue}
+            label={option.label}
+          />
         );
       })}
-    </div>
+    </RadioGroup>
   );
 }
 

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -1,5 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
+import {
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+} from "@carecloud/material-cuil";
 
 import { asNumber } from "../../utils";
 
@@ -41,55 +47,61 @@ function SelectWidget(props) {
     id,
     options,
     value,
+    label,
     required,
     disabled,
     readonly,
     multiple,
-    autofocus,
     onChange,
     onBlur,
     onFocus,
-    placeholder,
   } = props;
   const { enumOptions, enumDisabled } = options;
   const emptyValue = multiple ? [] : "";
+
   return (
-    <select
-      id={id}
-      multiple={multiple}
-      className="form-control"
-      value={typeof value === "undefined" ? emptyValue : value}
-      required={required}
-      disabled={disabled || readonly}
-      autoFocus={autofocus}
-      onBlur={
-        onBlur &&
-        (event => {
+    <FormControl disabled={disabled || readonly} required={required}>
+      <InputLabel htmlFor={id}>{label}</InputLabel>
+
+      <Select
+        id={id}
+        value={typeof value === "undefined" ? emptyValue : value}
+        label={label}
+        multiple={multiple}
+        disabled={disabled || readonly}
+        required={required}
+        onBlur={
+          onBlur &&
+          (event => {
+            const newValue = getValue(event, multiple);
+            onBlur(id, processValue(schema, newValue));
+          })
+        }
+        onFocus={
+          onFocus &&
+          (event => {
+            const newValue = getValue(event, multiple);
+            onFocus(id, processValue(schema, newValue));
+          })
+        }
+        onChange={event => {
           const newValue = getValue(event, multiple);
-          onBlur(id, processValue(schema, newValue));
-        })
-      }
-      onFocus={
-        onFocus &&
-        (event => {
-          const newValue = getValue(event, multiple);
-          onFocus(id, processValue(schema, newValue));
-        })
-      }
-      onChange={event => {
-        const newValue = getValue(event, multiple);
-        onChange(processValue(schema, newValue));
-      }}>
-      {!multiple && !schema.default && <option value="">{placeholder}</option>}
-      {enumOptions.map(({ value, label }, i) => {
-        const disabled = enumDisabled && enumDisabled.indexOf(value) != -1;
-        return (
-          <option key={i} value={value} disabled={disabled}>
-            {label}
-          </option>
-        );
-      })}
-    </select>
+          onChange(processValue(schema, newValue));
+        }}>
+        {enumOptions.map(({ value, label }, index) => {
+          const disabled = enumDisabled && enumDisabled.indexOf(value) !== -1;
+
+          return (
+            <MenuItem
+              key={index}
+              value={value}
+              className={disabled ? "disabled" : ""}>
+              {label}
+            </MenuItem>
+          );
+        })}
+      </Select>
+    </FormControl>
   );
 }
 


### PR DESCRIPTION
**Changes**:
- Use MUI components for: string, select, checkbox, radio, radio group and checkbox group.
- Use MUI components for label and help/error text.
- Change package name to be scope to @carecloud.
- Change package version to 0.1.0

**Ticket**: https://jira.carecloud.com/browse/EAG-96
**Reviewers**: @amartin-carecloud

### Reasons for making this change

[Please describe them here]

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
