### PR TITLE
[EAG-96 hotfix] Fix dist build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react": ">=15"
   },
   "dependencies": {
-    "@carecloud/material-cuil": "0.1.0",
+    "@carecloud/material-cuil": "0.2.0",
     "ajv": "^5.2.3",
     "lodash.topath": "^4.5.2",
     "prop-types": "^15.5.8",
@@ -54,9 +54,12 @@
     "babel-loader": "^6.2.7",
     "babel-plugin-react-transform": "^2.0.2",
     "babel-plugin-transform-class-properties": "^6.18.0",
+    "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
+    "babel-plugin-transform-es3-property-literals": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-0": "^6.24.1",
     "babel-register": "^6.18.0",
     "chai": "^3.3.0",
     "codemirror": "^5.30.0",


### PR DESCRIPTION
**Changes**:
- Fix dist build by adding missing babel plugins.
- Bump material-cuil to 0.2.0.

**Ticket**: https://jira.carecloud.com/browse/EAG-96
**Reviewers**: @amartin-carecloud