### PR TITLE
[EAG-395] Use material-cuil's DatePicker as the new Date widget.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carecloud/react-jsonschema-form",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build:readme": "toctoc README.md -w",
@@ -44,13 +44,13 @@
     "react-dom": "^16.2.0"
   },
   "dependencies": {
-    "@carecloud/material-cuil": "0.6.0",
+    "@carecloud/material-cuil": "0.7.0",
     "ajv": "^5.2.3",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-plugin-transform-runtime": "^6.23.0",
     "lodash": "^4.17.4",
     "lodash.topath": "^4.5.2",
-    "prop-types": "^15.5.8",
+    "prop-types": "^15.6.0",
     "setimmediate": "^1.0.5"
   },
   "devDependencies": {

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -84,7 +84,6 @@ function DefaultTemplate(props) {
     displayLabel,
     disabled,
     readonly,
-    schema,
     uiSchema,
     useDiv,
   } = props;
@@ -101,11 +100,6 @@ function DefaultTemplate(props) {
   const labelProps = {
     htmlFor: id,
   };
-
-  // TODO: remove this once a datepikcer is implemented
-  if (schema.format === 'date') {
-    labelProps.shrink = true;
-  }
 
   const ContainerComp = useDiv ? 'div' : FormControl;
   const containerProps = useDiv
@@ -191,10 +185,6 @@ function SchemaFieldRender(props) {
     case 'array':
       displayLabel =
         isMultiSelect(schema, definitions) || isFilesArray(schema, uiSchema, definitions);
-
-      break;
-    case 'date':
-      displayLabel = false;
 
       break;
     case 'object':

--- a/src/components/widgets/DateWidget.js
+++ b/src/components/widgets/DateWidget.js
@@ -1,15 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function DateWidget(props) {
-  const { onChange, registry: { widgets: { BaseInput } } } = props;
-  return <BaseInput type="date" {...props} onChange={value => onChange(value || undefined)} />;
-}
+import { DatePicker } from '@carecloud/material-cuil';
 
-if (process.env.NODE_ENV !== 'production') {
-  DateWidget.propTypes = {
-    value: PropTypes.string,
-  };
-}
+const DateWidget = props => {
+  return <DatePicker {...props} />;
+};
+
+DateWidget.propTypes = {
+  value: PropTypes.object,
+};
 
 export default DateWidget;


### PR DESCRIPTION
**Changes**:
- Use material-cuil's DatePicker as the new Date widget.
- Bump material-cuil@0.7.0

**Ticket**: https://jira.carecloud.com/browse/EAG-395
**Reviewers**: @rcarranza-carecloud @jleyba-carecloud @nbroda-carecloud