### PR TITLE
Add index property to SchemaField, when rendering ordered properties.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carecloud/react-jsonschema-form",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build:readme": "toctoc README.md -w",

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -98,7 +98,12 @@ class ObjectField extends Component {
       description,
       TitleField,
       DescriptionField,
-      properties: orderedProperties.map(name => {
+      properties: orderedProperties.map((name, index) => {
+        const fieldUiSchema = {
+          'ui:index': index,
+          ...(uiSchema[name] || {}),
+        };
+
         return {
           content: (
             <SchemaField
@@ -106,7 +111,7 @@ class ObjectField extends Component {
               name={name}
               required={this.isRequired(name)}
               schema={schema.properties[name]}
-              uiSchema={uiSchema[name]}
+              uiSchema={fieldUiSchema}
               errorSchema={errorSchema[name]}
               idSchema={idSchema[name]}
               formData={formData[name]}
@@ -116,6 +121,7 @@ class ObjectField extends Component {
               registry={registry}
               disabled={disabled}
               readonly={readonly}
+              index={index}
             />
           ),
           name,

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -311,6 +311,7 @@ if (process.env.NODE_ENV !== 'production') {
       FieldTemplate: PropTypes.func,
       formContext: PropTypes.object.isRequired,
     }),
+    index: PropTypes.number,
   };
 }
 


### PR DESCRIPTION
The `index` property has been added to:

- `SchemaField`, as a property, and will get passed down to the actual FieldComponent (one of `src/components/fields`).
- `SchemaField`, as part of the `uiSchema` property, using the name `ui:index`, and will get passed down to Widgets like `props.options.index`.

@efernandez-carecloud @rcarranza-carecloud @jleyba-carecloud 