### PR TITLE
Support `ui:componentProps` in uiSchema.

### DIFF
--- a/src/components/fields/TitleField.js
+++ b/src/components/fields/TitleField.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { FormLabel } from '@carecloud/material-cuil';
 
 const REQUIRED_FIELD_SYMBOL = '*';

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { InputWithClear } from '@carecloud/material-cuil';
+
+import { getComponentProps } from '../../utils';
 
 function BaseInput(props) {
   // Note: since React 15.2.0 we can't forward unknown element attributes, so we
@@ -32,6 +35,7 @@ function BaseInput(props) {
       autoFocus={autofocus}
       value={value == null ? '' : value}
       {...inputProps}
+      {...getComponentProps(props)}
       placeholder={inputProps.placeholder || inputProps.label}
       onChange={_onChange}
       onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}

--- a/src/components/widgets/CheckboxWidget.js
+++ b/src/components/widgets/CheckboxWidget.js
@@ -1,7 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import DescriptionField from '../fields/DescriptionField.js';
+
 import { FormControlLabel, Checkbox } from '@carecloud/material-cuil';
+
+import { getComponentProps } from '../../utils';
+import DescriptionField from '../fields/DescriptionField.js';
+
+export function FormCheckbox(props) {
+  const { id, value, required, disabled, label, onChange, checked, ...otherProps } = props;
+
+  return (
+    <FormControlLabel
+      control={<Checkbox id={id} {...otherProps} />}
+      required={required}
+      disabled={disabled}
+      checked={checked}
+      value={value}
+      onChange={onChange}
+      label={label}
+    />
+  );
+}
 
 function CheckboxWidget(props) {
   const { schema, id, value, required, disabled, readonly, label, onChange } = props;
@@ -10,17 +29,14 @@ function CheckboxWidget(props) {
     <div className={`checkbox ${disabled || readonly ? 'disabled' : ''}`}>
       {schema.description && <DescriptionField description={schema.description} />}
 
-      <FormControlLabel
-        control={
-          <Checkbox
-            id={id}
-            checked={typeof value === 'undefined' ? false : value}
-            value={value ? value.toString() : ''}
-            required={required}
-            disabled={disabled || readonly}
-            onChange={event => onChange(event.target.checked)}
-          />
-        }
+      <FormCheckbox
+        id={id}
+        required={required}
+        disabled={disabled || readonly}
+        {...getComponentProps(props)}
+        checked={typeof value === 'undefined' ? false : value}
+        value={value ? value.toString() : ''}
+        onChange={event => onChange(event.target.checked)}
         label={label}
       />
     </div>
@@ -32,6 +48,16 @@ CheckboxWidget.defaultProps = {
 };
 
 if (process.env.NODE_ENV !== 'production') {
+  FormCheckbox.propTypes = {
+    id: PropTypes.string.isRequired,
+    value: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+    required: PropTypes.bool,
+    disabled: PropTypes.bool,
+    autofocus: PropTypes.bool,
+    onChange: PropTypes.func,
+    label: PropTypes.string,
+  };
+
   CheckboxWidget.propTypes = {
     schema: PropTypes.object.isRequired,
     id: PropTypes.string.isRequired,
@@ -41,6 +67,7 @@ if (process.env.NODE_ENV !== 'production') {
     readonly: PropTypes.bool,
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
+    label: PropTypes.string,
   };
 }
 

--- a/src/components/widgets/CheckboxWidget.js
+++ b/src/components/widgets/CheckboxWidget.js
@@ -54,7 +54,7 @@ if (process.env.NODE_ENV !== 'production') {
     required: PropTypes.bool,
     disabled: PropTypes.bool,
     autofocus: PropTypes.bool,
-    onChange: PropTypes.func,
+    onChange: PropTypes.func.isRequired,
     label: PropTypes.string,
   };
 
@@ -66,7 +66,7 @@ if (process.env.NODE_ENV !== 'production') {
     disabled: PropTypes.bool,
     readonly: PropTypes.bool,
     autofocus: PropTypes.bool,
-    onChange: PropTypes.func,
+    onChange: PropTypes.func.isRequired,
     label: PropTypes.string,
   };
 }

--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -73,7 +73,7 @@ if (process.env.NODE_ENV !== 'production') {
     disabled: PropTypes.bool,
     multiple: PropTypes.bool,
     autofocus: PropTypes.bool,
-    onChange: PropTypes.func,
+    onChange: PropTypes.func.isRequired,
   };
 }
 

--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormControlLabel, FormGroup, Checkbox } from '@carecloud/material-cuil';
+
+import { FormGroup } from '@carecloud/material-cuil';
+
+import { FormCheckbox } from './CheckboxWidget';
 
 function selectValue(value, selected, all) {
   const at = all.indexOf(value);
@@ -26,25 +29,21 @@ function CheckboxesWidget(props) {
         const checked = value.indexOf(option.value) !== -1;
 
         return (
-          <FormControlLabel
+          <FormCheckbox
             key={index}
-            control={
-              <Checkbox
-                id={`${id}_${index}`}
-                checked={checked}
-                onChange={event => {
-                  const all = enumOptions.map(({ value }) => value);
+            id={`${id}_${index}`}
+            checked={checked}
+            value={option.value}
+            disabled={isDisabled}
+            onChange={event => {
+              const all = enumOptions.map(({ value }) => value);
 
-                  if (event.target.checked) {
-                    onChange(selectValue(option.value, value, all));
-                  } else {
-                    onChange(deselectValue(option.value, value));
-                  }
-                }}
-                value={option.value}
-                disabled={isDisabled}
-              />
-            }
+              if (event.target.checked) {
+                onChange(selectValue(option.value, value, all));
+              } else {
+                onChange(deselectValue(option.value, value));
+              }
+            }}
             label={option.label}
           />
         );

--- a/src/components/widgets/ColorWidget.js
+++ b/src/components/widgets/ColorWidget.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import { ColorPicker } from '@carecloud/material-cuil';
 
+import { getComponentProps } from '../../utils';
+
 const ColorWidget = props => {
   const {
     value,
@@ -26,6 +28,7 @@ const ColorWidget = props => {
       color={value}
       disableAlpha={disableAlpha}
       {...otherProps}
+      {...getComponentProps(props)}
     />
   );
 };

--- a/src/components/widgets/DateWidget.js
+++ b/src/components/widgets/DateWidget.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import { DatePicker } from '@carecloud/material-cuil';
 
+import { getComponentProps } from '../../utils';
+
 const DateWidget = props => {
   const { placeholder, options, ...otherProps } = props;
   const { dateDisplayFormat, timeIntervals } = options;
@@ -13,6 +15,7 @@ const DateWidget = props => {
       placeholderText={placeholder}
       dateDisplayFormat={dateDisplayFormat}
       timeIntervals={timeIntervals}
+      {...getComponentProps(props)}
     />
   );
 };

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { FormControlLabel, RadioGroup, Radio } from '@carecloud/material-cuil';
+
+import { getComponentProps } from '../../utils';
 
 function RadioWidget(props) {
   const { id, options, value, required, disabled, readonly, onChange } = props;
@@ -37,7 +40,7 @@ function RadioWidget(props) {
           <FormControlLabel
             key={index}
             disabled={isDisabled}
-            control={<Radio />}
+            control={<Radio {...getComponentProps(props)} />}
             value={optionValue}
             label={option.label}
           />

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -67,7 +67,7 @@ if (process.env.NODE_ENV !== 'production') {
     disabled: PropTypes.bool,
     readonly: PropTypes.bool,
     autofocus: PropTypes.bool,
-    onChange: PropTypes.func,
+    onChange: PropTypes.func.isRequired,
   };
 }
 export default RadioWidget;

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Select } from '@carecloud/material-cuil';
 import { get } from 'lodash';
 
-// TODO: Maybe this is necessary in the future, further testing is needed
-function processValue({ type }, value) {
+import { Select } from '@carecloud/material-cuil';
+
+import { getComponentProps } from '../../utils';
+
+function processValue(value) {
   return value === '' || value === null ? undefined : value;
 }
 
@@ -18,11 +20,11 @@ class SelectWidget extends React.Component {
     this.state = { options: null, isLoading: !!async };
   }
 
-  componentDidMount = () => {
+  componentDidMount() {
     if (this.async) {
       this.loadOptions();
     }
-  };
+  }
 
   /**
    * Generate an array of options objects from enumOptions and enumDisabled.
@@ -92,18 +94,32 @@ class SelectWidget extends React.Component {
     return value === undefined ? '' : value;
   };
 
+  onBlur = value => {
+    if (this.props.onBlur) {
+      this.props.onBlur(this.props.id, processValue(value));
+    }
+  };
+
+  onFocus = value => {
+    if (this.props.onFocus) {
+      this.props.onFocus(this.props.id, processValue(value));
+    }
+  };
+
+  onChange = value => {
+    if (this.props.onChange) {
+      this.props.onChange(processValue(value));
+    }
+  };
+
   render = () => {
     const {
       id,
-      schema,
       value,
       required,
       disabled,
       readonly,
       multiple: multi,
-      onChange,
-      onBlur,
-      onFocus,
       label,
       placeholder,
       autofocus,
@@ -131,22 +147,11 @@ class SelectWidget extends React.Component {
     return (
       <Select
         {...selectProps}
+        {...getComponentProps(this.props)}
         autoFocus={autofocus}
-        onBlur={
-          onBlur &&
-          (value => {
-            onBlur(id, processValue(schema, value));
-          })
-        }
-        onFocus={
-          onFocus &&
-          (value => {
-            onFocus(id, processValue(schema, value));
-          })
-        }
-        onChange={value => {
-          onChange(processValue(schema, value));
-        }}
+        onBlur={this.onBlur}
+        onFocus={this.onFocus}
+        onChange={this.onChange}
       />
     );
   };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import 'setimmediate';
+import { get, isObject as _isObject } from 'lodash';
+
 import validateFormData from './validate';
-import { isObject as _isObject } from 'lodash';
 
 const widgetMap = {
   boolean: {
@@ -683,5 +684,5 @@ export function rangeSpec(schema) {
 }
 
 export function getComponentProps(props) {
-  return props && props.options && props.options.componentProps ? props.options.componentProps : {};
+  return get(props, 'options.componentProps', {}) || {};
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -681,3 +681,7 @@ export function rangeSpec(schema) {
   }
   return spec;
 }
+
+export function getComponentProps(props) {
+  return props && props.options && props.options.componentProps ? props.options.componentProps : {};
+}


### PR DESCRIPTION
**Changes**:
- Support `ui:componentProps` in uiSchema: properties passed as is to the underlying component (from material-cuil). For more information, look at the`PropTypes` of the specific component. This will only make sense for properties defined as literals.
- Reuse `CheckboxWidget` inside `CheckboxesWidget`.