### PR TITLE
Simplify containers render.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carecloud/react-jsonschema-form",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build:readme": "toctoc README.md -w",

--- a/src/components/alfresco/AlfrescoForm.jsx
+++ b/src/components/alfresco/AlfrescoForm.jsx
@@ -27,39 +27,6 @@ const style = ({ theme }) => ({
 
 class AlfrescoForm extends Component {
 
-  /**
-   * Transform column to rows.
-   * @param columns: array of arrays representing columns
-   */
-  columnsToRows = columns => {
-    if (!columns) {
-      return [];
-    }
-
-    return columns.map(column => {
-      const rows = [];
-
-      column.forEach((fields, colIndex) => {
-        if (!Array.isArray(fields)) {
-          return false;
-        }
-
-        fields.forEach((field, rowIndex) => {
-          let row = rows[rowIndex];
-
-          if (!row) {
-            row = [];
-            rows.push(row);
-          }
-
-          row.splice(colIndex, 0, field);
-        });
-      });
-
-      return rows;
-    });
-  };
-
   renderContainerTitle = ({ id, title }) => {
     if (!title) {
       return null;
@@ -72,12 +39,12 @@ class AlfrescoForm extends Component {
     const { classes } = this.props;
     const { containers } = this.props.uiSchema['ui:alfresco'];
 
-    return Object.keys(containers).map((containerKey, containerIndex) => {
-      const containerProperty = this.props.schema.properties[containerKey];
+    return containers.map((container, containerIndex) => {
+      const containerProperty = this.props.schema.properties[container.id];
 
       // Arrays should be passed through
       if (containerProperty && containerProperty.type === 'array') {
-        const component = this.props.properties.filter(property => property.name === containerKey)[0];
+        const component = this.props.properties.filter(property => property.name === container.id)[0];
 
         return (
           <Grid item key={containerIndex} xs={12} className={classes.arrayContainer}>
@@ -86,8 +53,7 @@ class AlfrescoForm extends Component {
         );
       }
 
-      const container = containers[containerKey];
-      const fields = this.columnsToRows(container.fields);
+      const fields = container.fields;
 
       // Ignore empty containers
       if (!fields || !fields.length) {

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { range } from 'lodash';
 
 import { Button, Icons } from '@carecloud/material-cuil';
 
@@ -516,32 +515,19 @@ class ArrayField extends Component {
     return <Template {...arrayProps} />;
   }
 
-  setAlfrescoSchema = (itemSchema, itemUiSchema, numberOfColumns) => {
+  setAlfrescoSchema = (itemSchema, itemUiSchema, uiSchema) => {
     if (itemSchema && itemSchema.properties) {
-      const fields = [];
-
-      // Get number of columns (defaulting to 3)
-      const propKeys = Object.keys(itemSchema.properties);
-      numberOfColumns = numberOfColumns || Math.min(propKeys.length, 3);
-
-      // Fields should be grouped by columns
-      range(numberOfColumns).forEach(() => {
-        fields.push([]);
-      });
-
-      // Default to 3 columns
-      propKeys.forEach((propKey, fieldIndex) => {
-        fields[fieldIndex % numberOfColumns].push(propKey);
-      });
+      const { numberOfColumns, rows } = uiSchema;
 
       itemUiSchema['ui:array'] = true;
       itemUiSchema['ui:alfresco'] = {
-        containers: {
-          array: {
-            fields: [fields],
+        containers: [
+          {
+            id: 'array',
+            fields: [rows],
             numberOfColumns,
           },
-        },
+        ],
       };
     }
   };
@@ -575,7 +561,7 @@ class ArrayField extends Component {
     };
     has.toolbar = Object.keys(has).some(key => has[key]);
 
-    this.setAlfrescoSchema(itemSchema, itemUiSchema, uiSchema.numberOfColumns);
+    this.setAlfrescoSchema(itemSchema, itemUiSchema, uiSchema);
 
     return {
       children: (


### PR DESCRIPTION
After https://github.com/CareCloud/json-schema-tools/pull/41 gets merged, containers would already be translated to rows, instead of columns, so rendering is simplified.