### PR TITLE
EAG-1031 - BaseInput now supports formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carecloud/react-jsonschema-form",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "dev": "rimraf lib && cross-env NODE_ENV=production babel -d lib/ src/",
@@ -39,7 +39,7 @@
     "react-dom": "^16.2.0"
   },
   "dependencies": {
-    "@carecloud/material-cuil": "1.2.0",
+    "@carecloud/material-cuil": "1.4.0",
     "ajv": "^5.2.3",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -28,12 +28,15 @@ function BaseInput(props) {
     return props.onChange(value === '' ? options.emptyValue : value);
   };
 
+  const { format } = options;
+
   return (
     <InputWithClear
       className="form-control"
       disabled={disabled || readonly}
       autoFocus={autofocus}
       value={value == null ? '' : value}
+      format={format}
       {...inputProps}
       {...getComponentProps(props)}
       placeholder={inputProps.placeholder || inputProps.label}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5422,6 +5422,15 @@ react-transition-group@^2.2.1:
     loose-envify "^1.3.1"
     prop-types "^15.6.1"
 
+react@16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 reactcss@^1.2.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/reactcss/-/reactcss-1.2.3.tgz#c00013875e557b1cf0dfd9a368a1c3dab3b548dd"


### PR DESCRIPTION
### Reasons for making this change

The UI prop format is now being passed along to the InputWithClear component for input formatting

### Checklist

* [x] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
